### PR TITLE
Remove WPCOM action that modifies credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Colophon
 Having set up footer links in many partner sites, this aims to
 simplify the deployment of each, by using a more consistent api.
 
+WPCOM
+=====
+
+<em>Only on WPCOM sites</em><br>
+Removes the WPCOM ```better_wpcom_link_init``` action that modifies the credit links, so we can use our own.
+
 Usage
 =====
 

--- a/colophon.php
+++ b/colophon.php
@@ -123,3 +123,13 @@ add_action(
 		add_shortcode( 'team51-credits', 'team51_credits_shortcode' );
 	}
 );
+
+/**
+ * Remove WPCOM action for modifying credit links. So, we can add our own. [Only on WPCOM sites]
+ */
+function team51_remove_better_wpcom_links() {
+	remove_action( 'get_footer', 'better_wpcom_link_init' );
+}
+
+add_action( 'wp_footer', 'team51_remove_better_wpcom_links' );
+


### PR DESCRIPTION
### Changes proposed in this PR

- Removed the ```better_wpcom_link_init``` action that modifies the credit links, so we can use our own on WPCOM sites.