### PR TITLE
Bump plugin version

### DIFF
--- a/colophon.php
+++ b/colophon.php
@@ -3,7 +3,7 @@
 Plugin Name: Colophon
 Plugin URI: https://github.com/a8cteam51/colophon
 Description: Sets Team 51 footer links to WordPress.com and Pressable.
-Version: 1.0.0
+Version: 1.1.0
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 License: GPLv3


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There's no way to easily tell which version of the plugin a site is using. This commit bumps the version number from `1.0.0` to `1.1.0` to reflect recent changes, and is part of the effort to update all Team 51 sites to a version which includes `rel="nofollow"` links.

Ref: https://github.com/a8cteam51/team51-dev-requests/issues/3519
