### PR TITLE
Add a new shortcode for displaying the copyright symbol and year

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Change WordPress link text to be “Proudly designed with WordPress”:
 <!-- /wp:shortcode -->
 ```
 
+Add a copyright year in the format “© 2024”:
+
+```html
+<!-- wp:shortcode -->
+[team51-copyright-year]
+<!-- /wp:shortcode -->
+```
+
 
 
 Installation
@@ -122,3 +130,8 @@ git submodule add https://github.com/a8cteam51/colophon mu-plugins/colophon
 ```
 
 Then we create a pull request as needed and integrate it as above.
+
+
+### Updates
+
+* v1.2.0 Add a new shortcode for showing the copyright year.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Parameters can be passed in --
 * `pressable` -- The text displayed for the backlink to Pressable  
   Defaults to `Hosted by Pressable.`  
   Link is skipped if not truthy.
+* `format` -- The date format to use with the `[team51-current-year]` shortcode.
+  Defaults to `Y`.
 
 Customization
 =============
@@ -72,6 +74,15 @@ or
 or the like.  It will also accept `wpcom` and `pressable` parameters
 as well to specify their respective link texts.
 
+For inserting the current year, use this:
+
+```html
+<!-- wp:shortcode -->
+[team51-current-year]
+<!-- /wp:shortcode -->
+```
+
+... will output "2024", or whatever the current year is.
 
 
 ### Examples
@@ -92,11 +103,11 @@ Change WordPress link text to be “Proudly designed with WordPress”:
 <!-- /wp:shortcode -->
 ```
 
-Add a copyright year in the format “© 2024”:
+Add the current year in the format “24”:
 
 ```html
 <!-- wp:shortcode -->
-[team51-copyright-year]
+[team51-current-year format="y"]
 <!-- /wp:shortcode -->
 ```
 

--- a/colophon.php
+++ b/colophon.php
@@ -3,7 +3,7 @@
 Plugin Name: Colophon
 Plugin URI: https://github.com/a8cteam51/colophon
 Description: Sets Team 51 footer links to WordPress.com and Pressable.
-Version: 1.1.0
+Version: 1.2.0
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 License: GPLv3
@@ -125,6 +125,28 @@ if ( ! function_exists( 'team51_credits_shortcode' ) ) :
 		'init',
 		function () {
 			add_shortcode( 'team51-credits', 'team51_credits_shortcode' );
+		}
+	);
+endif;
+
+if ( ! function_exists( 'team51_copyright_shortcode' ) ) :
+
+	/**
+	 * The Shortcode for `[team51-copyright-year]`.
+	 *
+	 * Can also be used in the Shortcode block.
+	 *
+	 * @return string
+	 */
+	function team51_copyright_shortcode() {
+		$current_year = gmdate( 'Y' );
+		$output       = "&copy; $current_year";
+		return esc_html( $output );
+	}
+	add_action(
+		'init',
+		function () {
+			add_shortcode( 'team51-copyright-year', 'team51_copyright_shortcode' );
 		}
 	);
 endif;

--- a/colophon.php
+++ b/colophon.php
@@ -129,24 +129,33 @@ if ( ! function_exists( 'team51_credits_shortcode' ) ) :
 	);
 endif;
 
-if ( ! function_exists( 'team51_copyright_shortcode' ) ) :
+if ( ! function_exists( 'team51_current_year_shortcode' ) ) :
 
 	/**
-	 * The Shortcode for `[team51-copyright-year]`.
+	 * The Shortcode for `[team51-current-year]`.
 	 *
 	 * Can also be used in the Shortcode block.
 	 *
+	 * @param array{format?: string} $atts The Args passed to the function.
+	 *
 	 * @return string
 	 */
-	function team51_copyright_shortcode() {
-		$current_year = gmdate( 'Y' );
-		$output       = "&copy; $current_year";
-		return esc_html( $output );
+	function team51_current_year_shortcode( $atts ) {
+		$atts = shortcode_atts(
+			array(
+				'format' => 'Y',
+			),
+			$atts,
+			'current_year'
+		);
+
+		$current_year = gmdate( $atts['format'] );
+		return esc_html( $current_year );
 	}
 	add_action(
 		'init',
 		function () {
-			add_shortcode( 'team51-copyright-year', 'team51_copyright_shortcode' );
+			add_shortcode( 'team51-current-year', 'team51_current_year_shortcode' );
 		}
 	);
 endif;

--- a/colophon.php
+++ b/colophon.php
@@ -146,7 +146,7 @@ if ( ! function_exists( 'team51_current_year_shortcode' ) ) :
 				'format' => 'Y',
 			),
 			$atts,
-			'current_year'
+			'team51-current-year'
 		);
 
 		$current_year = gmdate( $atts['format'] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new, automatically updating current year shortcode.
* Technically, and current "date" can be used with the shortcode depending on the date format passed in the shortcode parameters.

#### Testing instructions

* In a new shortcode block, add the shortcode `[team51-current-year]`.
* View the page/location on the front-end where the shortcode was added.
* The format should be in the form "2024".
* Test versions with parameters, eg `[team51-current-year format='y']`, for output like "24".
* Most [standard formats](https://www.php.net/manual/en/datetime.format.php) should also work.

Ref: https://a8c.slack.com/archives/C01M1J49Q75/p1705055606476879
