### PR TITLE
Adds filter to get the credits link as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ Parameters can be passed in --
   Defaults to `Hosted by Pressable.`  
   Link is skipped if not truthy.
 * `format` -- The date format to use with the `[team51-current-year]` shortcode.
-* `return_output` -- Defines if the output should be echoed or returned.
-  Defaults to `false` to keep standard echo behavior.
-  Only makes a difference in do_action and not in the shortcode
 
 Customization
 =============

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Parameters can be passed in --
   Defaults to `Hosted by Pressable.`  
   Link is skipped if not truthy.
 * `format` -- The date format to use with the `[team51-current-year]` shortcode.
-  Defaults to `Y`.
+* `return_output` -- Defines if the output should be echoed or returned.
+  Defaults to `false` to keep standard echo behavior.
+  Only makes a difference in do_action and not in the shortcode
 
 Customization
 =============

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Parameters can be passed in --
   Defaults to `Hosted by Pressable.`  
   Link is skipped if not truthy.
 * `format` -- The date format to use with the `[team51-current-year]` shortcode.
+  Defaults to `Y`. 
 
 Customization
 =============

--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ Then we create a pull request as needed and integrate it as above.
 ### Updates
 
 * v1.2.0 Add a new shortcode for showing the copyright year.
+* v1.3.0 Adds a new filter that returns the credits link string instead of echoing it.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ for more graceful degradation to implement via actions.
 <?php do_action( 'team51_credits', array() ); ?>
 ```
 
+If we need just the final credits link returned as string we can also use
+
+```php
+<?php apply_filters( 'team51_credits_filter', '', array() ); ?>
+```
+
 Parameters can be passed in --
 
 * `separator` -- defaults to a single space.  

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Parameters can be passed in --
   Defaults to `Hosted by Pressable.`  
   Link is skipped if not truthy.
 * `format` -- The date format to use with the `[team51-current-year]` shortcode.
-  Defaults to `Y`. 
+  Defaults to `Y`.
 
 Customization
 =============

--- a/colophon.php
+++ b/colophon.php
@@ -18,17 +18,18 @@ if ( ! function_exists( 'team51_credits' ) ) :
 	 *
 	 * @param array{separator?: string, wpcom?: string, pressable?: string} $args The Args passed to the function.
 	 *
-	 * @return void
+	 * @return void|string
 	 */
 	function team51_credits( $args = array() ) {
 		$args = wp_parse_args(
 			$args,
 			array(
-				'separator' => ' ',
+				'separator'     => ' ',
 				/* translators: %s: WordPress. */
-				'wpcom'     => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
+				'wpcom'         => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
 				/* translators: %s: Pressable. */
-				'pressable' => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
+				'pressable'     => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
+				'return_output' => false,
 			)
 		);
 
@@ -88,10 +89,16 @@ if ( ! function_exists( 'team51_credits' ) ) :
 		 */
 		$credit_links = apply_filters( 'team51_credit_links', $credit_links, $args );
 
-		echo implode(
+		$output = implode(
 			esc_html( $args['separator'] ),
 			$credit_links //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, this cant be escaped as it runs through a filter
 		);
+
+		if ( $args['return_output'] ) {
+			return $output;
+		}
+
+		echo $output; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, this cant be escaped as it runs through a filter
 	}
 	add_action( 'team51_credits', 'team51_credits', 10, 1 );
 endif;

--- a/colophon.php
+++ b/colophon.php
@@ -11,6 +11,21 @@ License: GPLv3
 
 if ( ! function_exists( 'team51_credits' ) ) :
 
+
+	/**
+	 * A wrapper to the colophon generating method for WordPress Special Projects Sites.
+	 * Echoes a the resulting credit links
+	 *
+	 * Usage: team51_credits( 'separator= | ' );
+	 *
+	 * @param array{separator?: string, wpcom?: string, pressable?: string} $args The Args passed to the function.
+	 *
+	 * @return void
+	 */
+	function team51_credits( $args = array() ) {
+		echo apply_filters( 'team51_credits_filter', '', $args ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
 	/**
 	 * A colophon-generating method for WordPress Special Projects Sites.
 	 *
@@ -18,9 +33,9 @@ if ( ! function_exists( 'team51_credits' ) ) :
 	 *
 	 * @param array{separator?: string, wpcom?: string, pressable?: string} $args The Args passed to the function.
 	 *
-	 * @return void|string
+	 * @return string the resulting credits link
 	 */
-	function team51_credits( $args = array() ) {
+	function team51_credits_filter( $str = '', $args = array() ) {
 		$args = wp_parse_args(
 			$args,
 			array(
@@ -29,7 +44,6 @@ if ( ! function_exists( 'team51_credits' ) ) :
 				'wpcom'         => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
 				/* translators: %s: Pressable. */
 				'pressable'     => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
-				'return_output' => false,
 			)
 		);
 
@@ -89,18 +103,14 @@ if ( ! function_exists( 'team51_credits' ) ) :
 		 */
 		$credit_links = apply_filters( 'team51_credit_links', $credit_links, $args );
 
-		$output = implode(
+		return implode(
 			esc_html( $args['separator'] ),
 			$credit_links //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, this cant be escaped as it runs through a filter
 		);
-
-		if ( $args['return_output'] ) {
-			return $output;
-		}
-
-		echo $output; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, this cant be escaped as it runs through a filter
 	}
+
 	add_action( 'team51_credits', 'team51_credits', 10, 1 );
+	add_filter( 'team51_credits_filter', 'team51_credits_filter', 10, 2 );
 endif;
 
 if ( ! function_exists( 'team51_credits_shortcode' ) ) :

--- a/colophon.php
+++ b/colophon.php
@@ -3,7 +3,7 @@
 Plugin Name: Colophon
 Plugin URI: https://github.com/a8cteam51/colophon
 Description: Sets Team 51 footer links to WordPress.com and Pressable.
-Version: 1.2.0
+Version: 1.3.0
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 License: GPLv3

--- a/colophon.php
+++ b/colophon.php
@@ -31,6 +31,7 @@ if ( ! function_exists( 'team51_credits' ) ) :
 	 *
 	 * Usage: team51_credits( 'separator= | ' );
 	 *
+	 * @param string $str The string that will be used for the filter. Will be overriden
 	 * @param array{separator?: string, wpcom?: string, pressable?: string} $args The Args passed to the function.
 	 *
 	 * @return string the resulting credits link

--- a/colophon.php
+++ b/colophon.php
@@ -39,11 +39,11 @@ if ( ! function_exists( 'team51_credits' ) ) :
 		$args = wp_parse_args(
 			$args,
 			array(
-				'separator'     => ' ',
+				'separator' => ' ',
 				/* translators: %s: WordPress. */
-				'wpcom'         => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
+				'wpcom'     => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
 				/* translators: %s: Pressable. */
-				'pressable'     => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
+				'pressable' => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
 			)
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* New option `return_output` that basically allows the final site credits to be returned instead of echoed.
* If no value is passed the default behavior keeps being the current one: credits are echoed.

This is needed cause when the string is echoed automatically the only way to catch it to pass it through in a filter, for instance, is to use `ob_start` etc... However, this doesn't work IF the filter is called within an existing ob_start already which is the case I am working on

#### Testing instructions

* Checkout this and build the plugin
* Install it on a site you own
* Create a new page or post and add a shortcode block with the plugin's shortcode to confirm things still work
  * Bonus if you test the shortcode with the new arg to confirm nothing breaks (the new arg shouldn't be considered in the shortcode)
* Add the following to the site (or to a snippet using the code snippets plugin):
```
add_action( 'wp_footer', function(){ do_action('team51_credits', array() ); } );
add_action( 'wp_footer', function(){ echo '<br/>'; } );
add_action( 'wp_footer', function () { echo apply_filters('team51_credits_filter', '', array('pressable' => '') ); },14);
```
 
