### PR TITLE
Add a way to get the colophon back as a string, rather than echoing.

### DIFF
--- a/colophon.php
+++ b/colophon.php
@@ -16,7 +16,7 @@ if ( ! function_exists( 'team51_credits' ) ) :
 	 *
 	 * Usage: team51_credits( 'separator= | ' );
 	 *
-	 * @param array{separator?: string, wpcom?: string, pressable?: string} $args The Args passed to the function.
+	 * @param array{separator?: string, wpcom?: string, pressable?: string, return?: boolean} $args The Args passed to the function.
 	 *
 	 * @return void
 	 */
@@ -32,6 +32,11 @@ if ( ! function_exists( 'team51_credits' ) ) :
 				'return'    => false,
 			)
 		);
+
+		// Protect against folks mistakenly passing 'return' in which would prevent anything from echoing on the action.
+		if ( doing_action( 'team51_credits' ) ) {
+			$args['return'] = false;
+		}
 
 		$credit_links   = array();
 		$parsed_url     = wp_parse_url( get_site_url(), PHP_URL_HOST );

--- a/colophon.php
+++ b/colophon.php
@@ -29,6 +29,7 @@ if ( ! function_exists( 'team51_credits' ) ) :
 				'wpcom'     => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
 				/* translators: %s: Pressable. */
 				'pressable' => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
+				'return'    => false,
 			)
 		);
 
@@ -88,10 +89,18 @@ if ( ! function_exists( 'team51_credits' ) ) :
 		 */
 		$credit_links = apply_filters( 'team51_credit_links', $credit_links, $args );
 
-		echo implode(
+		$output = implode(
 			esc_html( $args['separator'] ),
 			$credit_links //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, this cant be escaped as it runs through a filter
 		);
+
+		// If we'd rather it be returned, rather than echoed ...
+		if ( $args['return'] ) {
+			return $output;
+		}
+
+		// Otherwise...
+		echo $output;
 	}
 	add_action( 'team51_credits', 'team51_credits', 10, 1 );
 endif;
@@ -117,10 +126,9 @@ if ( ! function_exists( 'team51_credits_shortcode' ) ) :
 		);
 
 		$atts = shortcode_atts( $pairs, $atts, 'team51-credits' );
+		$atts['return'] = true;
 
-		ob_start();
-		team51_credits( $atts );
-		return ob_get_clean();
+		return team51_credits( $atts );
 	}
 	add_action(
 		'init',

--- a/colophon.php
+++ b/colophon.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'team51_credits' ) ) :
 	 *
 	 * @param array{separator?: string, wpcom?: string, pressable?: string, return?: boolean} $args The Args passed to the function.
 	 *
-	 * @return void
+	 * @return void|string
 	 */
 	function team51_credits( $args = array() ) {
 		$args = wp_parse_args(
@@ -101,11 +101,11 @@ if ( ! function_exists( 'team51_credits' ) ) :
 
 		// If we'd rather it be returned, rather than echoed ...
 		if ( $args['return'] ) {
-			return $output;
+			return wp_kses_post( $output );
 		}
 
 		// Otherwise...
-		echo $output;
+		echo esc_attr( $output );
 	}
 	add_action( 'team51_credits', 'team51_credits', 10, 1 );
 endif;
@@ -131,6 +131,7 @@ if ( ! function_exists( 'team51_credits_shortcode' ) ) :
 		);
 
 		$atts = shortcode_atts( $pairs, $atts, 'team51-credits' );
+
 		$atts['return'] = true;
 
 		return team51_credits( $atts );


### PR DESCRIPTION
This will remedy an issue where there can be fatal errors from nested output buffers with callbacks -- for example:

```
[01-Feb-2024 16:46:28 UTC] PHP Fatal error:  ob_start(): Cannot use output buffering in output buffering display handlers
```

As an added bonus, it lets us stop using output buffers in the shortcode version, and just ask for the string directly.

Alternate resolution to #25 -- enabling just calling the method directly, rather than filtering.

#### Changes proposed in this Pull Request

* Less output buffering.  More joy.

