### PR TITLE
Update link to `mu-loader` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ First, ensure the following two lines are included in your `.gitignore` so that 
 !mu-plugins/colophon
 ```
 
-If `mu-loader.php` is not already in the `mu-plugins` directory, it can be copied from https://github.com/Automattic/team51-cli/blob/trunk/scaffold/templates/mu-loader.php
+If `mu-loader.php` is not already in the `mu-plugins` directory, it can be copied from https://github.com/a8cteam51/team51-project-scaffold/blob/trunk/mu-plugins/mu-loader.php
 
 This can be done on cli from the repository root via:
 
 ```
 mkdir mu-plugins
-curl https://raw.githubusercontent.com/Automattic/team51-cli/trunk/scaffold/templates/mu-loader.php -o mu-plugins/mu-loader.php
+curl https://github.com/a8cteam51/team51-project-scaffold/blob/trunk/mu-plugins/mu-loader.php -o mu-plugins/mu-loader.php
 ```
 
 From the project repository's root, we add the Colophon as a submodule via


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates link to the `mu-loader` plugin in the README file. The site scaffolding was removed from the new Team 51 CLI, and we should be using the one from the site scaffold instead.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the updated link works in the instructions and command.