### PR TITLE
Update default WordPress text to "Designed with WordPress"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ for more graceful degradation to implement via actions.
 <?php do_action( 'team51_credits', array() ); ?>
 ```
 
-The default output is "Proudly powered by WordPress. Hosted by Pressable."
+The default output is "Designed with WordPress. Hosted by Pressable."
 
 Parameters can be passed in --
 
 * `separator` -- defaults to a single space.  
   Separator is passed through `esc_html()` on output, so don't include html tags.
 * `wpcom` -- The text displayed for the backlink to WordPress.com  
-  Defaults to `Proudly powered by WordPress.`  
+  Defaults to `Designed with WordPress.`  
   Link is skipped if not truthy.
 * `pressable` -- The text displayed for the backlink to Pressable  
   Defaults to `Hosted by Pressable.`  

--- a/colophon.php
+++ b/colophon.php
@@ -26,7 +26,7 @@ if ( ! function_exists( 'team51_credits' ) ) :
 			array(
 				'separator' => ' ',
 				/* translators: %s: WordPress. */
-				'wpcom'     => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
+				'wpcom'     => sprintf( __( 'Designed with %s.', 'team51' ), 'WordPress' ),
 				/* translators: %s: Pressable. */
 				'pressable' => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
 			)
@@ -111,7 +111,7 @@ if ( ! function_exists( 'team51_credits_shortcode' ) ) :
 		$pairs = array(
 			'separator' => ' ',
 			/* translators: %s: WordPress. */
-			'wpcom'     => sprintf( __( 'Proudly powered by %s.', 'team51' ), 'WordPress' ),
+			'wpcom'     => sprintf( __( 'Designed with %s.', 'team51' ), 'WordPress' ),
 			/* translators: %s: Pressable. */
 			'pressable' => sprintf( __( 'Hosted by %s.', 'team51' ), 'Pressable' ),
 		);


### PR DESCRIPTION
### Summary
- Updates the default credit text from "Proudly powered by WordPress" to "Designed with WordPress" in both the plugin and README

### Changes
- `colophon.php`: Updated default `wpcom` text in `team51_credits()` and `team51_credits_shortcode()`
- `README.md`: Updated documentation to reflect the new default text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default WordPress credit messaging from "Proudly powered by WordPress" to "Designed with WordPress" in backlinks and site colophon displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->